### PR TITLE
documents function options must follow name

### DIFF
--- a/doc_src/function.txt
+++ b/doc_src/function.txt
@@ -2,7 +2,7 @@
 
 \subsection function-synopsis Synopsis
 \fish{synopsis}
-function [OPTIONS] NAME; BODY; end
+function NAME [OPTIONS]; BODY; end
 \endfish
 
 \subsection function-description Description


### PR DESCRIPTION
This pull request just swaps the location of the function name and options in the synopsis for `function`.

Previously, the synopsis showed options preceding the function name. This turns out not to work in practice. For example, defining

```
function -a arg test_fn
    echo "$_: my arg is $arg"
end
```

and subsequently trying to use `test_fn` gives `fish: unknown command 'test_fn'`.

The examples at the end of the documentation for `function` all show the arguments following the function name, so it was just the synopsis that needed updating.
